### PR TITLE
test errors fixed

### DIFF
--- a/AxiomFramework/Tests/AxiomTests/Core/AxiomContextTests.swift
+++ b/AxiomFramework/Tests/AxiomTests/Core/AxiomContextTests.swift
@@ -540,15 +540,6 @@ func testObservableObjectBehavior() async throws {
 
 // MARK: - Supporting Test Infrastructure
 
-/// Weak reference wrapper for observers
-struct WeakObserver {
-    weak var observer: AnyObject?
-    
-    init(_ observer: AnyObject) {
-        self.observer = observer
-    }
-}
-
 // MARK: - AxiomContext Performance Tests
 
 @Test("AxiomContext resource access performance")

--- a/AxiomFramework/Tests/AxiomTests/SwiftUI/ContextBindingTests.swift
+++ b/AxiomFramework/Tests/AxiomTests/SwiftUI/ContextBindingTests.swift
@@ -551,7 +551,8 @@ struct ContextBindingTests {
         try await Task.sleep(for: .milliseconds(200))
         
         let duration = ContinuousClock.now - startTime
-        let updatesPerSecond = Double(updateCount) / duration.seconds
+        let durationSeconds = Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1e18
+        let updatesPerSecond = Double(updateCount) / durationSeconds
         
         cancellable.cancel()
         
@@ -803,29 +804,4 @@ struct ContextBindingTests {
     }
 }
 
-// MARK: - Memory Tracker Utility
 
-struct MemoryTracker {
-    static func currentUsage() -> Int {
-        var info = mach_task_basic_info()
-        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size)/4
-        
-        let result = withUnsafeMutablePointer(to: &info) {
-            $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
-                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
-            }
-        }
-        
-        return result == KERN_SUCCESS ? Int(info.resident_size) : 0
-    }
-}
-
-// MARK: - Weak Observer
-
-struct WeakObserver {
-    weak var observer: AnyObject?
-    
-    init(_ observer: AnyObject) {
-        self.observer = observer
-    }
-}

--- a/AxiomFramework/Tests/AxiomTests/SwiftUI/ViewIntegrationTests.swift
+++ b/AxiomFramework/Tests/AxiomTests/SwiftUI/ViewIntegrationTests.swift
@@ -591,41 +591,19 @@ struct ViewIntegrationTests {
     // MARK: - SwiftUI Type Safety Tests
     
     @Test("SwiftUI compile-time type safety")
+    @MainActor
     func testCompileTimeTypeSafety() throws {
         // This test validates compile-time type relationships
         
-        // Valid view-context relationship should compile
-        struct ValidTestView: AxiomView {
-            typealias Context = TestSwiftUIContext
-            @ObservedObject var context: TestSwiftUIContext
-            
-            var body: some View {
-                Text("Valid")
-            }
-        }
-        
-        struct ValidTestContext: AxiomContext {
-            typealias View = ValidTestView
-            typealias Clients = TestSwiftUIClientContainer
-            
-            let clients: TestSwiftUIClientContainer = TestSwiftUIClientContainer()
-            let intelligence: any AxiomIntelligence = MockSwiftUIIntelligence()
-            
-            func onAppear() async {}
-            func onDisappear() async {}
-            func onClientStateChange<T: AxiomClient>(_ client: T) async {}
-            func handleError(_ error: any AxiomError) async {}
-            func trackAnalyticsEvent(_ event: String, parameters: [String: Any]) async {}
-        }
+        // Verify existing valid view-context relationship compiles
+        let context = TestSwiftUIContext()
+        let view = TestSwiftUIView(context: context)
         
         // Verify type relationships
-        #expect(ValidTestView.Context.self == ValidTestContext.self)
-        #expect(ValidTestContext.View.self == ValidTestView.self)
+        #expect(TestSwiftUIView.Context.self == TestSwiftUIContext.self)
+        #expect(TestSwiftUIContext.View.self == TestSwiftUIView.self)
         
-        // Create instances to verify runtime compatibility
-        let context = ValidTestContext()
-        let view = ValidTestView(context: context)
-        
+        // Verify runtime compatibility 
         #expect(view.context === context)
     }
     
@@ -743,12 +721,3 @@ struct ViewIntegrationTests {
     }
 }
 
-// MARK: - Weak Observer Support
-
-struct WeakObserver {
-    weak var observer: AnyObject?
-    
-    init(_ observer: AnyObject) {
-        self.observer = observer
-    }
-}

--- a/AxiomFramework/Tests/AxiomTests/TestUtilities.swift
+++ b/AxiomFramework/Tests/AxiomTests/TestUtilities.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+// MARK: - Shared Test Infrastructure
+
+/// Weak reference wrapper for observer management across all tests
+struct WeakObserver {
+    weak var observer: AnyObject?
+    
+    init(_ observer: AnyObject) {
+        self.observer = observer
+    }
+}
+
+/// Memory tracking utility for test performance monitoring
+struct MemoryTracker {
+    static func currentUsage() -> Int {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size)/4
+        
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        
+        return result == KERN_SUCCESS ? Int(info.resident_size) : 0
+    }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Centralized `WeakObserver` and `MemoryTracker` utilities in a shared file.
  - Removed duplicate definitions from multiple test files.
  - All tests now import from `TestUtilities.swift`.

- Fixed time and duration calculations for performance tests.
  - Replaced deprecated `.nanoseconds` with correct component-based calculations.
  - Improved accuracy and consistency in performance metrics.

- Improved SwiftUI test type safety and compilation checks.
  - Updated tests to verify type relationships using existing types.
  - Replaced runtime type checks with compile-time validation comments.

- Refactored view modifier extension placement for clarity.
  - Moved SwiftUI view modifier extensions to the end of the test file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestUtilities.swift</strong><dd><code>Add shared test utilities for observer and memory tracking</code></dd></summary>
<hr>

AxiomFramework/Tests/AxiomTests/TestUtilities.swift

<li>Added new file for shared test utilities.<br> <li> Centralized <code>WeakObserver</code> and <code>MemoryTracker</code> structs.<br> <li> Provides reusable infrastructure for all test files.


</details>


  </td>
  <td><a href="https://github.com/tojkuv/Axiom/pull/4/files#diff-5e629b0a32930746df1f30689277a3676e243b911c14a559120831050ed0854a">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AxiomContextTests.swift</strong><dd><code>Remove duplicate WeakObserver, use shared utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AxiomFramework/Tests/AxiomTests/Core/AxiomContextTests.swift

<li>Removed local <code>WeakObserver</code> struct.<br> <li> Now relies on shared utility from <code>TestUtilities.swift</code>.


</details>


  </td>
  <td><a href="https://github.com/tojkuv/Axiom/pull/4/files#diff-3b262b42b1d546cb23f560c16aff3bf92b06275b986bc073a3b5d62c28cbaedc">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PerformanceBenchmarkSuite.swift</strong><dd><code>Refactor utilities and fix performance calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AxiomFramework/Tests/AxiomTests/Performance/PerformanceBenchmarkSuite.swift

<li>Removed local <code>WeakObserver</code> and <code>MemoryTracker</code> structs.<br> <li> Updated all duration and nanosecond calculations for accuracy.<br> <li> Now uses shared utilities from <code>TestUtilities.swift</code>.


</details>


  </td>
  <td><a href="https://github.com/tojkuv/Axiom/pull/4/files#diff-1de5845e6f2c31d66b40852a6b3e42a10a1266db7a644b46cad37d34d25b17c0">+15/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContextBindingTests.swift</strong><dd><code>Use shared utilities and fix update rate calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AxiomFramework/Tests/AxiomTests/SwiftUI/ContextBindingTests.swift

<li>Removed local <code>WeakObserver</code> and <code>MemoryTracker</code> structs.<br> <li> Updated performance calculations for binding updates.<br> <li> Uses shared utilities from <code>TestUtilities.swift</code>.


</details>


  </td>
  <td><a href="https://github.com/tojkuv/Axiom/pull/4/files#diff-b11d511bd8c0c30798394157053187add7e74045fb49e26e92c8d31682a20807">+2/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ViewIntegrationTests.swift</strong><dd><code>Refactor type safety test and remove duplicate utility</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AxiomFramework/Tests/AxiomTests/SwiftUI/ViewIntegrationTests.swift

<li>Removed local <code>WeakObserver</code> struct.<br> <li> Updated type safety test to use existing types and compile-time <br>checks.<br> <li> Uses shared utility from <code>TestUtilities.swift</code>.


</details>


  </td>
  <td><a href="https://github.com/tojkuv/Axiom/pull/4/files#diff-18097ff08d88c27b3ee248dae28231e8a4321d78808c801b5d569170fda41750">+7/-38</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ViewModifiersTests.swift</strong><dd><code>Refactor view modifier extensions and update calculations</code></dd></summary>
<hr>

AxiomFramework/Tests/AxiomTests/SwiftUI/ViewModifiersTests.swift

<li>Refactored and moved view modifier extensions to file end.<br> <li> Removed local <code>WeakObserver</code> and <code>MemoryTracker</code> structs.<br> <li> Updated all performance and type safety calculations.<br> <li> Improved comments for compile-time validation.


</details>


  </td>
  <td><a href="https://github.com/tojkuv/Axiom/pull/4/files#diff-d193667f9306e770971b5a962db98292827047fb42955f185f553fe286974aef">+39/-59</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>